### PR TITLE
Update tag-support.csv

### DIFF
--- a/tag-support.csv
+++ b/tag-support.csv
@@ -842,7 +842,7 @@ Microsoft.Network,networkProfiles,TRUE,TRUE
 Microsoft.Network,networkSecurityGroups,TRUE,TRUE
 Microsoft.Network,networkWatchers,TRUE,TRUE
 Microsoft.Network,networkWatchers/connectionMonitors,TRUE,FALSE
-Microsoft.Network,networkWatchers/flowLogs,FALSE,FALSE
+Microsoft.Network,networkWatchers/flowLogs,TRUE,FALSE
 Microsoft.Network,networkWatchers/lenses,TRUE,FALSE
 Microsoft.Network,networkWatchers/pingMeshes,TRUE,FALSE
 Microsoft.Network,p2sVpnGateways,TRUE,TRUE


### PR DESCRIPTION
Update tag support boolean to TRUE for Microsoft.Network networkWatchers/flowLogs

We have a policy which applies the tags from a parent resource group to any resources created.  At one time it's true that tags could not be created on NSG flow logs, but we have noticed that tags are now being propagated by the policy.  The issue we are having is that we still have untagged flow logs since they were created before the change that allows these resources to be tagged was made.  We have created a runbook that will go out and apply missing tags and update incorrect tag values, but that runbook reads in the .csv file in this repo to determine whether a resource can be tagged or not; if the value is false, the resource is skipped.  We would like to request that this table be updated to reflect that flow logs can be tagged now.